### PR TITLE
986064: Resolve Failures in GitHub Repositories.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Once done with downloading, next you need to install the necessary packages requ
 ```
 npm install
 ```
+Make sure you have Angular CLI installed globally to avoid any compatibility issues during build and serve.
 
 ## Running
 
@@ -26,3 +27,4 @@ Finally, you can now use the below `ng` script to run the web application.
 ```
 ng serve
 ```
+This will compile the project and launch it in your default browser at localhost port.


### PR DESCRIPTION
### Bug description
[986064](https://dev.azure.com/EssentialStudio/Ej2-Web/_workitems/edit/986064/): Resolve Failures in GitHub Repositories

### Root cause,
The repository readme must have a minimum length of 1000 characters, whereas the current readme length is less than 1000 characters

### Reason for not identifying earlier
Find how it was missed in our earlier testing and development by analysing the below checklist. This will help prevent similar mistakes in the future. 

 - [x] Guidelines/documents are not followed

    - Specification document

 - [ ] Guidelines/documents are not given

    - Common guidelines / Core team guideline
    - Specification document
    - Requirement document


### Reason:

I have resolved by add the content in Readme description.

### Output screenshots:

NA

### Action taken:

I have resolved by add the content in Readme description.

### Related areas:

NA

### Is it a breaking issue?

No

### Solution description

I have resolved by add the content in Readme description.

### Areas affected and ensured

NA

### Additional checklist
This may vary for different teams or products. Check with your scrum masters.

  - Did you run the automation against your fix? Yes
  - Is there any API name change? No
  - Is there any existing behavior change of other features due to this code change? No
  - Does your new code introduce new warnings or binding errors? No
  - Does your code pass all FxCop and StyleCop rules? NA
  - Did you record this case in the unit test or UI test? NA
  - 